### PR TITLE
corrected autoencoder weight initialisation

### DIFF
--- a/neuralnetwork/autoencoder.py
+++ b/neuralnetwork/autoencoder.py
@@ -86,8 +86,8 @@ class CAE(nn.Module):
         for name, module in self.encoder.named_modules():
             if isinstance(module, nn.Conv1d) or isinstance(module, nn.Linear):
                 weight_init_dict[weight_init_name](module.weight)
-        for name, module in self.decoder.named_modules() or isinstance(module, nn.Linear):
-            if isinstance(module, nn.Conv1d):
+        for name, module in self.decoder.named_modules():
+            if isinstance(module, nn.Conv1d) or isinstance(module, nn.Linear):
                 weight_init_dict[weight_init_name](module.weight)
 
     def forward(self, input):


### PR DESCRIPTION
When initialising the decoder part of the autoencoder, `or isinstance(module, nn.Linear)` is put in the for loop instead of the if statement. This results in the weights of `'dec_linear_dense'` not being initialised correctly.